### PR TITLE
Delegate nix settings to users

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -100,24 +100,21 @@ in
         options.nix.nixPath.default;
 
       settings = {
-        experimental-features = [ "nix-command" "flakes" ];
+
+        trusted-users = [
+          "root"
+          "@wheel"
+        ];
 
         # Note: It seems like some of these subsituters might be better configured by the users.
         # Currenrly that requires that they are "trusted" users, this is less than optimal
         # but maybe preferable for the rosario accout (and maybe root?).
         # TODO: Invesitage
         substituters = [
-          "https://cache.zw3rk.com"
-          "https://cache.iog.io"
-          "https://iohk.cachix.org"
-          "https://nixcache.reflex-frp.org"
           "https://rosuavio-personal.cachix.org"
         ];
+
         trusted-public-keys = [
-          "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk="
-          "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-          "iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo="
-          "ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI="
           "rosuavio-personal.cachix.org-1:JE9iWA0eTZbknfGo2CtxMyxpbU7OjDFN4eCqKI7EmdI="
         ];
       };


### PR DESCRIPTION
Remove subsituters from system config that are not relivent to the
system config.
Remover client specific nix config from system config.
Delegate trust to "@wheel" users
