### PR TITLE
Remove nixos-rebuild and clear NIX_PATH

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -93,12 +93,10 @@ in
 
     time.timeZone = "America/New_York";
 
-    nix = {
-      # Remove default value for `nixos-config` from nixPath as I don't use it.
-      nixPath = lib.filter
-        (path: !lib.hasPrefix "nixos-config=" path)
-        options.nix.nixPath.default;
+    system.disableInstallerTools = true;
 
+    nix = {
+      nixPath = [ ];
       settings = {
 
         trusted-users = [


### PR DESCRIPTION
Removing nixos-rebuild from the system closure as its not needed in
normal system usage and its can be provided in a build shell.

Clear NIX_PATH as users can configure there own NIX_PATH variables and
they are not needed in normal system usage.
