### PR TITLE
Rebuild wrapper uses current system nixos-rebuild

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ in
     , pkgs ? import nixpkgs { }
     }:
     pkgs.writeShellScriptBin "nixos-rebuild" ''
-      exec ${pkgs.nixos-rebuild}/bin/nixos-rebuild \
+      exec /run/current-system/sw/bin/nixos-rebuild \
         -I nixpkgs=${nixpkgs} \
         -I nixos-config=${nixos-config} \
         "$@"

--- a/module/default.nix
+++ b/module/default.nix
@@ -93,8 +93,6 @@ in
 
     time.timeZone = "America/New_York";
 
-    system.disableInstallerTools = true;
-
     nix = {
       nixPath = [ ];
       settings = {


### PR DESCRIPTION
Re-enable installer tools.
Have nixos-rebuild wrapper wrap current system's nixos-rebuild instead
of nixos-rebuild from pin'ed nixpkgs. This means when local systems run
`nixos-rebuild` they use there current system's `nixos-rebuild` instead
of the `nixos-rebuild` from the system they are building.
This is more similar to common nixos installs, and more tested.
