### PR TITLE
Enable broadcasting and discovery of locally

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -85,6 +85,15 @@ in
 
     networking.networkmanager.enable = true;
 
+    services.avahi = {
+      enable = true;
+      nssmdns = true;
+      publish = {
+        enable = true;
+        addresses = true;
+      };
+    };
+
     environment.etc."NetworkManager/system-connections" = {
       source = "/persist/etc/NetworkManager/system-connections/";
     };


### PR DESCRIPTION
Use Avahi to have devices broadcast hostname and address to all
clients on the local network using mDNS.

Also enable nss querying of local hosts threw Avahi.
