### PR TITLE
Enable lanzaboote by default for all systems

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -1,13 +1,28 @@
 { config, options, pkgs, lib, ... }:
 let
   cfg = config;
+
+  sources = import ../nix/sources.nix;
+  lanzaboote = import sources.lanzaboote;
 in
 {
+  imports = [
+    lanzaboote.nixosModules.lanzaboote
+  ];
+
   options = {
     ocrOptimiztions = lib.mkEnableOption "ocrOptimiztions";
   };
 
   config = {
+    boot.loader.systemd-boot.enable = lib.mkForce false;
+
+    boot.lanzaboote = {
+      enable = true;
+      pkiBundle = "/etc/secureboot/";
+    };
+
+
     nixpkgs.config.allowUnfree = true;
 
     boot = {
@@ -76,10 +91,6 @@ in
 
     # TODO 2020.01.24 (RP) - Find a way to change the esp to "/esp"
     boot.loader = {
-      systemd-boot = {
-        enable = true;
-        editor = false;
-      };
       efi = {
         # efiSysMountPoint = "/boot/efi";
         canTouchEfiVariables = true;

--- a/module/polaris.nix
+++ b/module/polaris.nix
@@ -5,12 +5,10 @@ let
   hostName = "polaris";
 
   inherit (sources) nixos-hardware impermanence;
-  lanzaboote = import sources.lanzaboote;
 in
 {
   imports =
     [
-      lanzaboote.nixosModules.lanzaboote
       "${impermanence}/nixos.nix"
       "${nixos-hardware}/common/cpu/amd"
       "${nixos-hardware}/common/cpu/amd/pstate.nix"
@@ -24,13 +22,6 @@ in
   boot.kernelModules = [ "kvm-amd" "btqca" "btusb" "hci_qca" "hci_uart" "sg" "btintel" ];
 
   boot.initrd.availableKernelModules = [ "nvme" "xhci_pci" "ahci" "usb_storage" "usbhid" "sd_mod" ];
-
-  boot.loader.systemd-boot.enable = lib.mkForce false;
-
-  boot.lanzaboote = {
-    enable = true;
-    pkiBundle = "/etc/secureboot/";
-  };
 
   fileSystems."/" =
     {


### PR DESCRIPTION
Move lanzaboote configs from the polaris module to the default module
enabling lanzaboote for pulsar as well.
